### PR TITLE
feat(sheet-modal): adding sheet modal view

### DIFF
--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -29,6 +29,9 @@ struct ContentView: View {
         NavigationLink("Segment") {
           SegmentView()
         }
+        NavigationLink("Sheet Modal View") {
+          SheetModalView()
+        }
         NavigationLink("Tabs") {
           TabsView()
         }

--- a/App/SheetModalView.swift
+++ b/App/SheetModalView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+struct SheetModalView: View {
+    @State private var showSheet = false
+
+    var body: some View {
+        VStack {
+            Button("Show Bottom Sheet") {
+                showSheet = true
+            }
+        }
+        .sheet(isPresented: $showSheet) {
+            BottomSheetView()
+                .presentationDetents([
+                    .fraction(0.25),
+                    .medium,
+                    .fraction(0.8),
+                    .large
+                ])
+                .presentationDragIndicator(.visible)
+                .presentationContentInteraction(.scrolls)
+        }
+    }
+}
+
+struct BottomSheetView: View {
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Fixed Header
+            VStack {
+                Text("Header")
+                    .font(.headline)
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .background(Color(UIColor.systemGray6))
+            }
+
+            Divider()
+
+            // Scrollable Content
+            ScrollView {
+                VStack(spacing: 16) {
+                    ForEach(1..<30) { i in
+                        Text("Filler Content Row \(i)")
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding()
+                            .background(Color(UIColor.secondarySystemBackground))
+                            .cornerRadius(8)
+                    }
+                }
+                .padding()
+            }
+
+            Divider()
+
+            // Fixed Footer
+            VStack {
+                Button("Dismiss") {
+                    dismiss()
+                }
+                .padding()
+                .frame(maxWidth: .infinity)
+            }
+            .background(Color(UIColor.systemGray6))
+        }
+    }
+}
+
+struct SheetModalView_Previews: PreviewProvider {
+    static var previews: some View {
+        SheetModalView()
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ import AppleProductTypes
 let package = Package(
     name: "iOS Kitchen Sink",
     platforms: [
-        .iOS("15.2")
+        .iOS("16.4")
     ],
     products: [
         .iOSApplication(


### PR DESCRIPTION
Adding a sheet modal view, good for comparing to Framework sheet modals. Bumping to iOS 16.4 to support things like the sheet modal and breakpoints.